### PR TITLE
field_contents_foreign_linked - due to broken, with non model readonl…

### DIFF
--- a/suit/templates/admin/includes/fieldset.html
+++ b/suit/templates/admin/includes/fieldset.html
@@ -41,7 +41,7 @@
           {% endif %}
 
         {% if field.is_readonly %}
-            <span class="readonly">{{ field|field_contents_foreign_linked }}</span>
+            <span class="readonly">{{ field.contents }}</span>
         {% else %}
             {{ field.field }}
         {% endif %}

--- a/suit/templatetags/suit_tags.py
+++ b/suit/templatetags/suit_tags.py
@@ -45,41 +45,6 @@ def suit_time(parser, token):
 
 
 @register.filter
-def field_contents_foreign_linked(admin_field):
-    """Return the .contents attribute of the admin_field, and if it
-    is a foreign key, wrap it in a link to the admin page for that
-    object.
-
-    Use by replacing '{{ field.contents }}' in an admin template (e.g.
-    fieldset.html) with '{{ field|field_contents_foreign_linked }}'.
-    """
-    fieldname = admin_field.field['field']
-    obj = admin_field.form.instance
-    displayed = str(getattr(obj, fieldname)) if obj.id else ''
-
-    if not hasattr(admin_field.model_admin,
-                   'linked_readonly_fields') or fieldname not in admin_field \
-            .model_admin \
-            .linked_readonly_fields:
-        return displayed
-
-    try:
-        fieldtype, attr, value = lookup_field(fieldname, obj,
-                                              admin_field.model_admin)
-    except ObjectDoesNotExist:
-        fieldtype = None
-
-    if isinstance(fieldtype, ForeignKey):
-        try:
-            url = admin_url(value)
-        except NoReverseMatch:
-            url = None
-        if url:
-            displayed = "<a href='%s'>%s</a>" % (url, displayed)
-    return mark_safe(displayed)
-
-
-@register.filter
 def admin_url(obj):
     info = (obj._meta.app_label, obj._meta.object_name.lower())
     return reverse("admin:%s_%s_change" % info, args=[obj.pk])

--- a/suit/tests/templatetags/suit_tags.py
+++ b/suit/tests/templatetags/suit_tags.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.test import TestCase
 from suit import utils
 from suit.templatetags.suit_tags import suit_conf, suit_date, suit_time, \
-    admin_url, field_contents_foreign_linked, suit_bc, suit_bc_value
+    admin_url, suit_bc, suit_bc_value
 from django.db import models
 from django.contrib import admin
 from django.contrib.admin.helpers import AdminReadonlyField
@@ -70,25 +70,6 @@ class SuitTagsTestCase(TestCase):
         country = Country(pk=1, name='USA')
         assert '/country/1' in admin_url(country)
         pass
-
-    def test_field_contents_foreign_linked(self):
-        country = Country(pk=1, name='France')
-        city = City(pk=1, name='Paris', country=country)
-
-        ma = CityAdmin(City, admin.site)
-
-        # Create form
-        request = None
-        form = ma.get_form(request, city)()
-        form.instance = city
-        ro_field = AdminReadonlyField(form, 'country', True, ma)
-
-        self.assertEqual(country.name,
-                         field_contents_foreign_linked(ro_field))
-
-        # Now it should return as link
-        ro_field.model_admin.linked_readonly_fields = ('country',)
-        assert admin_url(country) in field_contents_foreign_linked(ro_field)
 
     def test_suit_bc(self):
         args = [utils.django_major_version(), 'a']


### PR DESCRIPTION
field_contents_foreign_linked - due to broken, with non model readonly_fields and no 'linked_readonly_fields' usage docs